### PR TITLE
Revert "Remove unused Qt6::Qml dependency breaking Apple Silicon build"

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -184,7 +184,7 @@ endif()
 
 # ---- Qt6 ----
 find_package(Qt6 REQUIRED COMPONENTS
-    Widgets Network Svg Concurrent Xml LinguistTools
+    Widgets Network Svg Concurrent Xml LinguistTools Qml
 )
 
 # ---- OpenMP ----
@@ -1079,6 +1079,7 @@ target_link_libraries(TStar PRIVATE
     Qt6::Network
     Qt6::Concurrent
     Qt6::Xml
+    Qt6::Qml
     ${CFITSIO_LIBRARY}
     ${GSL_LIBRARIES}
     ${OpenCV_LIBS}


### PR DESCRIPTION
Reverts Ft2801/TStar#16